### PR TITLE
doc: Fixes import path in main example code

### DIFF
--- a/packages/rx-scavenger/README.md
+++ b/packages/rx-scavenger/README.md
@@ -29,7 +29,7 @@ or `npm install --save @wishtack/rx-scavenger`
 ## Usage in an Angular component
 
 ```typescript
-import { Scavenger } from 'rx-scavenger';
+import { Scavenger } from '@wishtack/rx-scavenger';
 
 @Component({
     ...


### PR DESCRIPTION
package import path doesn't use the proper scoped package name