### PR TITLE
Updates core-js to 3+ & fixes related imports for Angular 8 compatibility

### DIFF
--- a/packages/rx-scavenger/package.json
+++ b/packages/rx-scavenger/package.json
@@ -27,13 +27,13 @@
     "url": "https://github.com/wishtack/wishtack-steroids.git"
   },
   "peerDependencies": {
-    "core-js": "^2.0.0",
+    "core-js": "^3.0.0",
     "rxjs": "^6.0.0"
   },
   "devDependencies": {
     "@types/jasmine": "^3.3.8",
     "clean-webpack-plugin": "^1.0.0",
-    "core-js": "^2.6.4",
+    "core-js": "^3.0.0",
     "istanbul-instrumenter-loader": "^3.0.1",
     "jasmine": "^3.1.0",
     "karma": "^4.0.0",

--- a/packages/rx-scavenger/src/scavenger.ts
+++ b/packages/rx-scavenger/src/scavenger.ts
@@ -5,8 +5,8 @@
  * $Id: $
  */
 
-import 'core-js/es6/map';
-import 'core-js/modules/es7.array.includes';
+import 'core-js/es/map';
+import 'core-js/modules/es.array.includes';
 
 import { OnDestroy } from '@angular/core';
 import { MonoTypeOperatorFunction, Observable, Subscription } from 'rxjs';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3542,10 +3542,15 @@ copy-webpack-plugin@4.6.0:
     p-limit "^1.0.0"
     serialize-javascript "^1.4.0"
 
-core-js@^2.2.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.0, core-js@^2.6.4:
+core-js@^2.2.0, core-js@^2.4.0, core-js@^2.5.0, core-js@^2.6.0:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.9.tgz#6b4b214620c834152e179323727fc19741b084f2"
   integrity sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==
+
+core-js@^3.0.0:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.3.3.tgz#b7048d3c6c1a52b5fe55a729c1d4ccdffe0891bb"
+  integrity sha512-0xmD4vUJRY8nfLyV9zcpC17FtSie5STXzw+HyYw2t8IIvmDnbq7RJUULECCo+NstpJtwK9kx8S+898iyqgeUow==
 
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
Angular 8 depends on core-js ^3.0.0 which removes version numbers from import paths